### PR TITLE
Feature: Deployment status API using Redis queue

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "AWS"
   ],
   "author": "David Harper <david@pandastrike.com>",
-  "contributors": ["Christoph Wagner <christoph@pandastrike.com>"],
+  "contributors": [
+    "Christoph Wagner <christoph@pandastrike.com>"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/pandastrike/panda-cluster-kick/issues"
@@ -30,6 +32,7 @@
     "aws-sdk": "^2.1.6",
     "c50n": "^0.7.2",
     "fairmont": "^1.0.0-alpha-04",
+    "mutual": "^1.0.0-alpha-03",
     "pbx": "^1.0.0-alpha-14",
     "pirate": "^1.0.0-alpha-05",
     "underscore": "^1.7.0",

--- a/src/db.coffee
+++ b/src/db.coffee
@@ -1,0 +1,4 @@
+{Memory} = require "pirate"
+
+# Temporary storage for records and their change IDs
+module.exports = Memory.Adapter.make()

--- a/src/events.coffee
+++ b/src/events.coffee
@@ -1,0 +1,9 @@
+{Channel, Transport} = require "mutual"
+
+# Set up a message channel to transmit status events
+# TODO: how to configure the Redis server's address?
+transport = Transport.Redis.Queue.create()
+# TODO: what do we name the channel?
+channel = Channel.create "hello", transport
+
+module.exports = channel

--- a/src/events.coffee
+++ b/src/events.coffee
@@ -1,9 +1,11 @@
 {Channel, Transport} = require "mutual"
+{parse} = require "url"
 
-# Set up a message channel to transmit status events
-# TODO: how to configure the Redis server's address?
-transport = Transport.Redis.Queue.create()
-# TODO: what do we name the channel?
-channel = Channel.create "hello", transport
+module.exports = (config) ->
+  {hostname} = parse config.api_server
+  # We assume the Redis server runs on the same host as the
+  # API server, and on the default port (6379)
+  # TODO: make port configurable
+  transport = Transport.Redis.Queue.create(host: hostname)
+  channel = Channel.create "huxley", transport
 
-module.exports = channel

--- a/src/handlers.coffee
+++ b/src/handlers.coffee
@@ -3,18 +3,15 @@ async = (require "when/generator").lift
 {discover} = (require "pbx").client
 {resolve} = require "path"
 {extend} = require "fairmont"
-{Memory} = require "pirate"
-{build_record, load} = require "./helpers"
+db = require "./db"
 channel = require "./events"
-
-# Temporary storage for records and their change IDs
-adapter = Memory.Adapter.make()
+{build_record, load} = require "./helpers"
 
 module.exports = async ->
 
   config = yield load (resolve __dirname, "../config/kick.cson")
   route53 = (require "./route53")(config.AWS)
-  records = yield adapter.collection "records"
+  records = yield db.collection "records"
 
   records:
     create: validate async ({respond, url, data}) ->

--- a/src/handlers.coffee
+++ b/src/handlers.coffee
@@ -4,7 +4,6 @@ async = (require "when/generator").lift
 {resolve} = require "path"
 {extend} = require "fairmont"
 db = require "./db"
-channel = require "./events"
 {build_record, load} = require "./helpers"
 
 module.exports = async ->
@@ -12,6 +11,7 @@ module.exports = async ->
   config = yield load (resolve __dirname, "../config/kick.cson")
   route53 = (require "./route53")(config.AWS)
   records = yield db.collection "records"
+  events = (require "./events")(config)
 
   records:
     create: validate async ({respond, url, data}) ->
@@ -69,5 +69,5 @@ module.exports = async ->
       status = yield data
       status.cluster_id = config.cluster_id
       status.timestamp = Date.now()
-      channel.emit {status}
+      events.emit {status}
       respond 201, "Created"

--- a/src/handlers.coffee
+++ b/src/handlers.coffee
@@ -18,9 +18,9 @@ module.exports = async ->
 
   # Set up a message channel to transmit status events
   # TODO: how to configure the Redis server's address?
-  transport = Transport.Queue.Redis.create()
+  transport = Transport.Redis.Queue.create()
   # TODO: what do we name the channel?
-  channel = Channel.create transport, "hello"
+  channel = Channel.create "hello", transport
 
   records:
     create: validate async ({respond, url, data}) ->

--- a/src/handlers.coffee
+++ b/src/handlers.coffee
@@ -4,8 +4,8 @@ async = (require "when/generator").lift
 {resolve} = require "path"
 {extend} = require "fairmont"
 {Memory} = require "pirate"
-{Channel, Transport} = require "mutual"
 {build_record, load} = require "./helpers"
+channel = require "./events"
 
 # Temporary storage for records and their change IDs
 adapter = Memory.Adapter.make()
@@ -15,12 +15,6 @@ module.exports = async ->
   config = yield load (resolve __dirname, "../config/kick.cson")
   route53 = (require "./route53")(config.AWS)
   records = yield adapter.collection "records"
-
-  # Set up a message channel to transmit status events
-  # TODO: how to configure the Redis server's address?
-  transport = Transport.Redis.Queue.create()
-  # TODO: what do we name the channel?
-  channel = Channel.create "hello", transport
 
   records:
     create: validate async ({respond, url, data}) ->

--- a/test/status.coffee
+++ b/test/status.coffee
@@ -19,7 +19,7 @@ describe "Kick Server", (context) ->
     for status in w "starting running failed shutting_down stopped"
       do (status) ->
         context.test "Status: #{status}", (context) ->
-          channel = Channel.create "hello", Transport.Redis.Queue.create()
+          channel = Channel.create "huxley", Transport.Redis.Queue.create()
 
           message = promise (resolve, reject) ->
             channel.once status: (status) ->

--- a/test/status.coffee
+++ b/test/status.coffee
@@ -2,19 +2,37 @@ assert = require "assert"
 {describe} = require "amen"
 {discover} = (require "pbx").client
 {w} = require "fairmont"
+{promise} = require "when"
+{Channel, Transport} = require "mutual"
  
 describe "Kick Server", (context) ->
+
+  console.log "====================================================="
+  console.log "This test requires a Redis server."
+  console.log "If tests are failing, make sure you are running a"
+  console.log "Redis server on localhost using the default port."
+  console.log "====================================================="
 
   context.test "Status events", (context) ->
     api = yield discover "http://localhost:8080"
 
     for status in w "starting running failed shutting_down stopped"
-      context.test "Status: #{status}", ->
-        yield api.status.create
-          application_id: "test"
-          deployment_id: "deadbeef"
-          service: "test-service"
-          status: status
+      do (status) ->
+        context.test "Status: #{status}", (context) ->
+          channel = Channel.create "hello", Transport.Redis.Queue.create()
+
+          message = promise (resolve, reject) ->
+            channel.once status: (status) ->
+              resolve status
+
+          yield api.status.create
+            application_id: "test"
+            deployment_id: "deadbeef"
+            service: "test-service"
+            status: status
+
+          assert.equal status, (yield message).status
+          channel.close()
 
     context.test "Wrong status type results in error", (context) ->
       try


### PR DESCRIPTION
## Summary

This is an enhanced version of #8 which uses a Redis queue to relay status events to the API server (instead of HTTP requests).

This implements https://github.com/pandastrike/huxley/issues/86 and https://github.com/pandastrike/huxley/issues/77.
## Details

This allows services to share their current status information.

``` bash
curl -XPOST kick.<cluster_name>.cluster:2000/status-d '{
"service": "test-service", 
"application_id": "<app_id>",
"deployment_id": "<deploy_id>",
"status":"starting",
"detail": "<optional, object or string>"
}' \
-H 'Content-Type: application/vnd.kick.status+json' 
```

The kick server adds the cluster's name and a timestamp and forwards everything to the Huxley API server.

The `status` field must be one of the following:
- `starting`
- `running`
- `failed`
- `shutting_down`
- `stopped`

This is validated by the server. Trying to submit a status that doesn't match these 5 choices will result in a 400 error.
### Configuration file

There are two new keys in `config/kick.cson`.

```
api_server: "api_server_name_goes_here"
cluster_id: "cluster_id_goes_here"
```

Panda-cluster will need to be updated to set these accordingly.
## Tests

Included. See `test/status.coffee`.
